### PR TITLE
Updated Tutorial.txt

### DIFF
--- a/doc/Tutorial.txt
+++ b/doc/Tutorial.txt
@@ -17,4 +17,4 @@ import tmd
 neuron = tmd.io.load_neuron('input_path_to_file/input_file.swc')
 
 # Extract the tmd of a neurite, i.e., neuronal tree
-pd = tmd.methods.get_ph_diagram(neuron.neurite[0])
+pd = tmd.methods.get_persistence_diagram(neuron.neurite[0])


### PR DESCRIPTION
The method `get_ph_diagram` does not exist. The correct one seems to be `get_persistence_diagram`.