### PR TITLE
check if .asc files as input

### DIFF
--- a/tmd/io/io.py
+++ b/tmd/io/io.py
@@ -122,6 +122,9 @@ def load_population(neurons, tree_types=None, name=None):
 
     pop = Population.Population(name=name)
 
+    if any([i.endswith(".asc") for i in files]):
+        raise Exception('You have some .asc files which cannot be used with TMD, please only use .h5 or .swc.')
+
     files2load = [i for i in files if (i.endswith(".h5") or i.endswith(".swc"))]
 
     for i in files2load:


### PR DESCRIPTION
Had the classic issue of inputing .asc files instead of .h5 or .swc, so added a line to raise an exception if some .asc files are givenb to TMD to generate distribution and parameters. 