### PR TITLE
Ignore secondary annotations (undefined annotations in TYPE_DCT)

### DIFF
--- a/tmd/io/io.py
+++ b/tmd/io/io.py
@@ -87,7 +87,7 @@ def load_neuron(input_file, line_delimiter='\n', soma_type=None,
         in_type_dct[:, ind] = data[:, 1] == int(TYPE)
     in_type_dct = _np.sum(in_type_dct, axis=1).astype(bool)
     if verbose and len(data) > _np.sum(in_type_dct):
-        raise LoadNeuronError('Loaded neuron data contains structural '
+        print('LoadNeuronWarning: Loaded neuron data contains structural '
                               'annotations that are ignored in current TMD '
                               ' package. Processed data only contains: %s'
                               % str(TYPE_DCT))

--- a/tmd/io/io.py
+++ b/tmd/io/io.py
@@ -46,7 +46,7 @@ def make_tree(data):
 
 
 def load_neuron(input_file, line_delimiter='\n', soma_type=None,
-                tree_types=None, remove_duplicates=True):
+                tree_types=None, remove_duplicates=True, verbose=True):
     '''
     Io method to load an swc or h5 file into a Neuron object.
     TODO: Check if tree is connected to soma, otherwise do
@@ -78,6 +78,20 @@ def load_neuron(input_file, line_delimiter='\n', soma_type=None,
         soma_ids = _np.where(_np.transpose(data)[1] == soma_index)[0]
     except IndexError:
         raise LoadNeuronError('Soma points not in the expected format')
+
+    # Remove structural annotations other than defined in TYPE_DICT
+    # Presence of those annotations impede loading of data when generating
+    # csr_matrix.
+    in_type_dct = _np.zeros((len(data), len(TYPE_DCT))).astype(bool)
+    for ind, TYPE in enumerate(TYPE_DCT.values()):
+        in_type_dct[:, ind] = data[:, 1] == int(TYPE)
+    in_type_dct = _np.sum(in_type_dct, axis=1).astype(bool)
+    if verbose and len(data) > _np.sum(in_type_dct):
+        raise LoadNeuronError('Loaded neuron data contains structural '
+                              'annotations that are ignored in current TMD '
+                              ' package. Processed data only contains: %s'
+                              % str(TYPE_DCT))
+    data = data[in_type_dct, :]
 
     # Extract soma information from swc
     soma = Soma.Soma(x=_np.transpose(data)[SWC_DCT['x']][soma_ids],


### PR DESCRIPTION
Usage of reconstruction data files with structural annotations for anatomical contours fail to load
in the current TMD package. This is because those annotations usually are not connected with the
soma or any of the processes (basal, apical, axon) as defined in TYPE_DCT. To allow for loading of
the data we can remove all data that is not defined in TYPE_DCT. A 'verbose' argument is added
to allow the user to avoid superfluous printing of the warning that data was removed.

I hope you find this edit useful, also included a test file that would in the current version of TMD 
cannot be read, but with the edit will be read. This file was converted from a neurolucida .DAT file to
SWCplus file with (https://neuroinformatics.nl/HBP/morphology-viewer/).


[BJ2510_a1_MSaa00455_PVAi9-4473_B2_traced_BCJ.swc.txt](https://github.com/BlueBrain/TMD/files/4088901/BJ2510_a1_MSaa00455_PVAi9-4473_B2_traced_BCJ.swc.txt)
*had to add .txt to allow for import 