### PR TITLE
lint fixes + improvement of some older code

### DIFF
--- a/tmd/Topology/analysis.py
+++ b/tmd/Topology/analysis.py
@@ -330,8 +330,6 @@ def find_apical_point_distance_smoothed(ph, threshold=0.1):
     based on the variation of the barcode.
     This algorithm always computes a distance, even if
     there is no obvious apical point.
-    If the apical point is after the distance to last bifurcation,
-    the returned distance is 0.9 times the last bifurcation distance.
     Threshold corresponds to percent of minimum derivative variation
     that is used to select the minima.
     '''
@@ -349,9 +347,7 @@ def find_apical_point_distance_smoothed(ph, threshold=0.1):
         minimas = np.where(abs(der1) < threshold * np.max(abs(der1)))[0]
         minimas = minimas[der2[minimas] > 0]
         threshold *= 2.  # if threshold was too small, increase and retry
-
-    last_bif = 0.9 * max(tmd_bar[1] for tmd_bar in ph)
-    return min(last_bif, bin_centers[minimas[0]])
+    return bin_centers[minimas[0]]
 
 
 def _symmetric(p):

--- a/tmd/Topology/analysis.py
+++ b/tmd/Topology/analysis.py
@@ -350,7 +350,7 @@ def find_apical_point_distance_smoothed(ph, threshold=0.1):
         minimas = minimas[der2[minimas] > 0]
         threshold *= 2.  # if threshold was too small, increase and retry
 
-    last_bif = 0.9 * max([tmd_bar[1] for tmd_bar in ph])
+    last_bif = 0.9 * max(tmd_bar[1] for tmd_bar in ph)
     return min(last_bif, bin_centers[minimas[0]])
 
 

--- a/tmd/Topology/analysis.py
+++ b/tmd/Topology/analysis.py
@@ -330,6 +330,8 @@ def find_apical_point_distance_smoothed(ph, threshold=0.1):
     based on the variation of the barcode.
     This algorithm always computes a distance, even if
     there is no obvious apical point.
+    If the apical point is after the distance to last bifurcation,
+    the returned distance is 0.9 times the last bifurcation distance.
     Threshold corresponds to percent of minimum derivative variation
     that is used to select the minima.
     '''
@@ -347,7 +349,9 @@ def find_apical_point_distance_smoothed(ph, threshold=0.1):
         minimas = np.where(abs(der1) < threshold * np.max(abs(der1)))[0]
         minimas = minimas[der2[minimas] > 0]
         threshold *= 2.  # if threshold was too small, increase and retry
-    return bin_centers[minimas[0]]
+
+    last_bif = 0.9 * max([tmd_bar[1] for tmd_bar in ph])
+    return min(last_bif, bin_centers[minimas[0]])
 
 
 def _symmetric(p):

--- a/tmd/Topology/methods.py
+++ b/tmd/Topology/methods.py
@@ -39,10 +39,10 @@ def get_persistence_diagram(tree, feature='radial_distances', **kwargs):
     children = {b: end[np.where(beg == b)[0]] for b in np.unique(beg)}
 
     while len(np.where(active)[0]) > 1:
-        alive = list(np.where(active)[0])
-        for l in alive:
+        alives = list(np.where(active)[0])
+        for alive in alives:
 
-            p = parents[l]
+            p = parents[alive]
             c = children[p]
 
             if np.alltrue(active[c]):
@@ -145,10 +145,10 @@ def get_ph_angles(tree, feature='radial_distances', **kwargs):
     angles = get_angles(tree, beg, parents, children)
 
     while len(np.where(active)[0]) > 1:
-        alive = list(np.where(active)[0])
-        for l in alive:
+        alives = list(np.where(active)[0])
+        for alive in alives:
 
-            p = parents[l]
+            p = parents[alive]
             c = children[p]
 
             if np.alltrue(active[c]):
@@ -194,10 +194,10 @@ def get_ph_radii(tree, feature='radial_distances', **kwargs):
     radii = get_section_mean_radii(tree, beg, end)
 
     while len(np.where(active)[0]) > 1:
-        alive = list(np.where(active)[0])
-        for l in alive:
+        alives = list(np.where(active)[0])
+        for alive in alives:
 
-            p = parents[l]
+            p = parents[alive]
             c = children[p]
 
             if np.alltrue(active[c]):

--- a/tmd/Topology/methods.py
+++ b/tmd/Topology/methods.py
@@ -38,8 +38,8 @@ def get_persistence_diagram(tree, feature='radial_distances', **kwargs):
 
     children = {b: end[np.where(beg == b)[0]] for b in np.unique(beg)}
 
-    while len(np.where(active)[0]) > 1:
-        alives = list(np.where(active)[0])
+    alives = np.where(active)[0]
+    while len(alives) > 1:
         for alive in alives:
 
             p = parents[alive]
@@ -58,8 +58,9 @@ def get_persistence_diagram(tree, feature='radial_distances', **kwargs):
                     ph.append([rd[ci], rd[p]])
 
                 rd[p] = rd[mx_id]
+        alives = np.where(active)[0]
 
-    ph.append([rd[np.where(active)[0][0]], 0])  # Add the last alive component
+    ph.append([rd[alives[0]], 0])  # Add the last alive component
 
     return ph
 
@@ -144,8 +145,8 @@ def get_ph_angles(tree, feature='radial_distances', **kwargs):
 
     angles = get_angles(tree, beg, parents, children)
 
-    while len(np.where(active)[0]) > 1:
-        alives = list(np.where(active)[0])
+    alives = np.where(active)[0]
+    while len(alives) > 1:
         for alive in alives:
 
             p = parents[alive]
@@ -165,8 +166,9 @@ def get_ph_angles(tree, feature='radial_distances', **kwargs):
                     ph.append([rd[ci], rd[p], angID[0], angID[1], angID[2], angID[3]])
 
                 rd[p] = rd[mx_id]
+        alives = np.where(active)[0]
 
-    ph.append([rd[np.where(active)[0][0]], 0, np.nan, np.nan, np.nan, np.nan])
+    ph.append([rd[alives[0]], 0, np.nan, np.nan, np.nan, np.nan])
 
     return ph
 
@@ -193,8 +195,8 @@ def get_ph_radii(tree, feature='radial_distances', **kwargs):
 
     radii = get_section_mean_radii(tree, beg, end)
 
-    while len(np.where(active)[0]) > 1:
-        alives = list(np.where(active)[0])
+    alives = np.where(active)[0]
+    while len(alives) > 1:
         for alive in alives:
 
             p = parents[alive]
@@ -214,8 +216,9 @@ def get_ph_radii(tree, feature='radial_distances', **kwargs):
                     ph.append([rd[ci], rd[p], radiiID])
 
                 rd[p] = rd[mx_id]
+        alives = np.where(active)[0]
 
-    ph.append([rd[np.where(active)[0][0]], 0, radii[beg[0]]])  # Add the last alive component
+    ph.append([rd[alives[0]], 0, radii[beg[0]]])  # Add the last alive component
 
     return ph
 

--- a/tmd/io/io.py
+++ b/tmd/io/io.py
@@ -117,7 +117,7 @@ def load_population(neurons, tree_types=None, name=None):
         files = neurons
         name = name if name is not None else 'Population'
     elif os.path.isdir(neurons):  # Assumes given input is a directory
-        files = [os.path.join(neurons, l) for l in os.listdir(neurons)]
+        files = [os.path.join(neurons, neuron_dir) for neuron_dir in os.listdir(neurons)]
         name = name if name is not None else os.path.basename(neurons)
 
     pop = Population.Population(name=name)

--- a/tmd/io/io.py
+++ b/tmd/io/io.py
@@ -76,8 +76,8 @@ def load_neuron(input_file, line_delimiter='\n', soma_type=None,
 
     try:
         soma_ids = _np.where(_np.transpose(data)[1] == soma_index)[0]
-    except IndexError:
-        raise LoadNeuronError('Soma points not in the expected format')
+    except IndexError as exc:
+        raise LoadNeuronError('Soma points not in the expected format') from exc
 
     # Extract soma information from swc
     soma = Soma.Soma(x=_np.transpose(data)[SWC_DCT['x']][soma_ids],
@@ -93,8 +93,8 @@ def load_neuron(input_file, line_delimiter='\n', soma_type=None,
         dA = sp.csr_matrix((_np.ones(len(p) - len(soma_ids)),
                            (range(len(soma_ids), len(p)),
                             p[len(soma_ids):])), shape=(len(p), len(p)))
-    except Exception:
-        raise LoadNeuronError('Cannot create connectivity, nodes not connected correctly.')
+    except Exception as exc:
+        raise LoadNeuronError('Cannot create connectivity, nodes not connected correctly.') from exc
 
     # assuming soma points are in the beginning of the file.
     comp = cs.connected_components(dA[len(soma_ids):, len(soma_ids):])
@@ -126,8 +126,8 @@ def load_population(neurons, tree_types=None, name=None):
         try:
             assert filename.endswith(('.h5', '.swc'))
             pop.append_neuron(load_neuron(filename, tree_types=tree_types))
-        except AssertionError:
-            raise Warning("{} is not a valid h5 or swc file".format(filename))
+        except AssertionError as exc:
+            raise Warning("{} is not a valid h5 or swc file".format(filename)) from exc
         except LoadNeuronError:
             print('File failed to load: {}'.format(filename))
 

--- a/tmd/view/__init__.py
+++ b/tmd/view/__init__.py
@@ -6,8 +6,8 @@ Matplotlib required.
 
 try:
     import matplotlib
-except ImportError:
+except ImportError as exc:
     raise ImportError('tmd[viewer] is not installed. ' +
-                      'Please install it by doing: pip install tmd[viewer]')
+                      'Please install it by doing: pip install tmd[viewer]') from exc
 
 from tmd.view import plot, view

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ extras = viewer
 commands = nosetests
 
 [testenv:py36-lint]
-basepython = python3
+basepython = python3.6
 deps =
     pycodestyle
     pylint


### PR DESCRIPTION
If the detected apical point is larger than the last bifurcation, the apical points it not a valid one. Forcing it to be 0.9* distance to last bif makes it a valid one. The choice of 0.9 is arbitrary, and originated because using a factor of 1 did not work later with TNS, possbily due to floating point precision. We can but a smaller fraction than 0.9.