### PR TITLE
Use points instead of diameters for MorphIO conversion

### DIFF
--- a/tmd/Population/Population.py
+++ b/tmd/Population/Population.py
@@ -9,11 +9,15 @@ class Population(object):
     A Population object is a container for Neurons.
     """
 
-    def __init__(self, name='Pop'):
+    def __init__(self, name='Pop', neurons=None):
         '''Creates an empty Population object.
         '''
         self.neurons = []
         self.name = name
+
+        if neurons:
+            for neuron in neurons:
+                self.append_neuron(neuron)
 
     @property
     def axon(self):

--- a/tmd/io/conversion.py
+++ b/tmd/io/conversion.py
@@ -17,11 +17,15 @@ def convert_morphio_soma(morphio_soma):
         tmd_soma (Soma)
     """
     points = morphio_soma.points
+    try:
+        d = morphio_soma.diameters
+    except AttributeError:
+        d = np.zeros(points.shape[0], dtype=points.dtype)
     return Soma(
         x=points[:, 0],
         y=points[:, 1],
         z=points[:, 2],
-        d=morphio_soma.diameters
+        d=d
     )
 
 
@@ -48,9 +52,14 @@ def _section_to_data(section, tree_length, start, parent):
     parents = np.arange(tree_length - 1, tree_length + n - 1, dtype=np.int)
     parents[0] = parent
 
+    try:
+        diameters = section.diameters[start:]
+    except AttributeError:
+        diameters = np.zeros(n, dtype=points.dtype)
+
     return n, SectionData(
         points[start:],
-        section.diameters[start:],
+        diameters,
         int(section.type),
         parents)
 
@@ -67,7 +76,7 @@ def convert_morphio_trees(morphio_neuron):
             - tree (Tree): The constructed tmd Tree
             - tree_types (dict): The neuron tree types
     """
-    total_points = len(morphio_neuron.diameters)
+    total_points = len(morphio_neuron.points)
 
     x = np.empty(total_points, dtype=np.float32)
     y = np.empty(total_points, dtype=np.float32)


### PR DESCRIPTION
NeuroM is now using MorphIO to read the morphologies so it would be nice to be able to convert a NeuroM morph into a TMD one.
The conversion from MorphIO used the diameters to get the number of points but sometimes this attribute is missing (for NeuroM objects with a SomaSimpleContour for example), so I think we can use the `points` attribute instead of the `diameters`. Does it look good for you?