### PR TITLE
CI: Fix action to publish new releases on Pypi

### DIFF
--- a/.github/workflows/publish-sdist.yml
+++ b/.github/workflows/publish-sdist.yml
@@ -20,7 +20,7 @@ jobs:
             python setup.py sdist
 
       - name: Publish distribution package to PyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
Fix this warning: https://github.com/BlueBrain/TMD/runs/7950770806?check_suite_focus=true#step:6:15